### PR TITLE
nix: Use types.lines for settings and autostart_sh

### DIFF
--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -72,7 +72,7 @@ in {
       };
       settings = mkOption {
         description = "mango config content";
-        type = types.str;
+        type = types.lines;
         default = "";
         example = ''
           # menu and terminal
@@ -82,7 +82,7 @@ in {
       };
       autostart_sh = mkOption {
         description = "WARRNING: This is a shell script, but no need to add shebang";
-        type = types.str;
+        type = types.lines;
         default = "";
         example = ''
           waybar &


### PR DESCRIPTION
Using `types.lines` for the options allows config from other files to be merged together, instead of conflicting like with `types.str`.