### PR TITLE
If focus_cross_monitor is enabled focusdir focuses the monitor if no clients available

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -86,6 +86,8 @@ void focusdir(const Arg *arg) {
 				viewtoleft_have_client(NULL);
 			if (arg->i == RIGHT || arg->i == DOWN)
 				viewtoright_have_client(NULL);
+		} else if (config.focus_cross_monitor) {
+			focusmon(arg);
 		}
 	}
 }


### PR DESCRIPTION
This PR enables `focusdir` to focus the monitor in that direction if there are no clients available, and `focus_cross_monitor` is true. I think this makes it more intuitive, requiring only one shortcut (`focusdir`) to focus the other monitor, whether there's a client or not.